### PR TITLE
Improve alertbox dismissal handling and Playwright CI coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,7 +34,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
         with:
           cache: true
@@ -44,7 +46,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: Run chromium Playwright tests
         run: pnpm exec playwright test --project=chromium
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-chromium
@@ -62,7 +64,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
         with:
           cache: true
@@ -72,7 +76,7 @@ jobs:
         run: pnpm exec playwright install --with-deps firefox
       - name: Run firefox Playwright tests
         run: pnpm exec playwright test --project=firefox
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-firefox
@@ -90,7 +94,9 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
         with:
           cache: true
@@ -100,7 +106,7 @@ jobs:
         run: pnpm exec playwright install --with-deps webkit
       - name: Run webkit Playwright tests
         run: pnpm exec playwright test --project=webkit
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-webkit

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
     inputs:
       browser:
@@ -16,6 +16,9 @@ on:
           - chromium
           - firefox
           - webkit
+
+permissions:
+  contents: read
 
 jobs:
   chromium:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,105 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: Browser project to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - chromium
+          - firefox
+          - webkit
+
 jobs:
-  test:
-    timeout-minutes: 60
+  chromium:
+    name: chromium
+    # PRs run Chromium for fast feedback. Pushes and manual "all" runs keep
+    # full cross-browser coverage through the firefox and webkit jobs below.
+    if: >-
+      ${{
+        github.event_name != 'workflow_dispatch' ||
+        inputs.browser == 'all' ||
+        inputs.browser == 'chromium'
+      }}
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
-      with:
-        cache: true
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
-    - name: Run Playwright tests
-      run: pnpm exec playwright test
-    - uses: actions/upload-artifact@v7
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/checkout@v6
+      - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
+        with:
+          cache: true
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install chromium browser
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run chromium Playwright tests
+        run: pnpm exec playwright test --project=chromium
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-chromium
+          path: playwright-report/
+          retention-days: 30
+
+  firefox:
+    name: firefox
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' &&
+          (inputs.browser == 'all' || inputs.browser == 'firefox'))
+      }}
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
+        with:
+          cache: true
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install firefox browser
+        run: pnpm exec playwright install --with-deps firefox
+      - name: Run firefox Playwright tests
+        run: pnpm exec playwright test --project=firefox
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-firefox
+          path: playwright-report/
+          retention-days: 30
+
+  webkit:
+    name: webkit
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' &&
+          (inputs.browser == 'all' || inputs.browser == 'webkit'))
+      }}
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/setup@9d7bc02973c0dd098fef6550b676299d84319358 # v0
+        with:
+          cache: true
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install webkit browser
+        run: pnpm exec playwright install --with-deps webkit
+      - name: Run webkit Playwright tests
+        run: pnpm exec playwright test --project=webkit
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-webkit
+          path: playwright-report/
+          retention-days: 30

--- a/components/alertbox/js/alertbox-manager.js
+++ b/components/alertbox/js/alertbox-manager.js
@@ -44,13 +44,6 @@ export class AlertBoxManager extends HTMLElement {
     }
   }
 
-  #containsBannerIdInStorage(bannerId) {
-    return (
-      this.#containsBannerIdForStorageType(bannerId, "session") ||
-      this.#containsBannerIdForStorageType(bannerId, "local")
-    );
-  }
-
   #containsBannerIdForStorageType(bannerId, storageType) {
     const storage = storageType === "session" ? sessionStorage : localStorage;
 
@@ -112,7 +105,7 @@ export class AlertBoxManager extends HTMLElement {
 
         if (
           this.isConnected &&
-          !this.#containsBannerIdInStorage(bannerId) &&
+          !this.#containsDismissedBanner(banner) &&
           this.#isWithinDateRange(banner)
         ) {
           const alertboxBanner = new AlertBoxBanner().getBanner(banner);
@@ -128,6 +121,18 @@ export class AlertBoxManager extends HTMLElement {
         throw error;
       }
     });
+  }
+
+  #containsDismissedBanner(banner) {
+    if (banner.dismissType === "session") {
+      return this.#containsBannerIdForStorageType(banner.id, "session");
+    }
+
+    if (banner.dismissType === "permanent") {
+      return this.#containsBannerIdForStorageType(banner.id, "permanent");
+    }
+
+    return false;
   }
 
   addBanner(banner) {
@@ -149,12 +154,12 @@ export class AlertBoxManager extends HTMLElement {
 
   #handleClick(event) {
     const target = event.target;
-    const dismissButton = target.closest(ALERTBOX_BANNER_DISMISS);
+    const dismissButton = target.closest(`.${ALERTBOX_BANNER_DISMISS}`);
     const actionButton = target.classList.contains(
       ALERTBOX_BANNER_ACTION_BUTTON,
     )
       ? target
-      : target.closest(ALERTBOX_BANNER_ACTION_BUTTON);
+      : target.closest(`.${ALERTBOX_BANNER_ACTION_BUTTON}`);
 
     if (actionButton) {
       emitBannerActionEvent(
@@ -176,7 +181,7 @@ export class AlertBoxManager extends HTMLElement {
       banner.remove();
 
       if (
-        dismissType &&
+        (dismissType === "session" || dismissType === "permanent") &&
         !this.#containsBannerIdForStorageType(bannerId, dismissType)
       ) {
         this.#storeBannerId(bannerId, dismissType);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,9 +21,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 1 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/tests/alertbox-daterange.spec.js
+++ b/tests/alertbox-daterange.spec.js
@@ -122,4 +122,6 @@ test("session dismissable banner can be dismissed, but is shown again in new con
 
   const newBanners = newPage.getByRole("status");
   await expect(newBanners).toHaveCount(2);
+
+  await context.close();
 });

--- a/tests/alertbox-daterange.spec.js
+++ b/tests/alertbox-daterange.spec.js
@@ -73,8 +73,10 @@ test("page dismissable banner can be dismissed, but is shown again after reload"
   const pageDismissableBanner = banners.filter({
     hasText: "is page dismissable",
   });
-  const pageDismissableBannerCloseButton =
-    pageDismissableBanner.getByRole("button");
+  const pageDismissableBannerCloseButton = pageDismissableBanner.getByRole(
+    "button",
+    { name: "Close" },
+  );
 
   await pageDismissableBannerCloseButton.click();
   await expect(pageDismissableBanner).not.toBeVisible();
@@ -111,10 +113,11 @@ test("session dismissable banner can be dismissed, but is shown again in new con
 
   await expect(sessionDismissableBanner).not.toBeVisible();
 
-  page.close();
+  await page.close();
 
   const context = await browser.newContext();
   const newPage = await context.newPage();
+  await newPage.clock.setFixedTime("2025-09-19");
   await newPage.goto("/components/alertbox/date-range.html");
 
   const newBanners = newPage.getByRole("status");

--- a/tests/alertbox-permanent.spec.js
+++ b/tests/alertbox-permanent.spec.js
@@ -22,7 +22,7 @@ test("permanent success banner has dismissible close button", async ({
   const successBannerCloseButton = page
     .getByRole("status")
     .filter({ hasText: "This is a permanent success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(successBanner).toBeAttached();
   await expect(successBannerCloseButton).toBeAttached();
@@ -39,7 +39,7 @@ test("dismissed permanent success banner is not shown again after reload", async
   const successBannerCloseButton = page
     .getByRole("status")
     .filter({ hasText: "This is a permanent success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(successBanner).toBeAttached();
   await expect(successBannerCloseButton).toBeAttached();
@@ -72,7 +72,7 @@ test("dismissed permanent success banner is not shown in new page", async ({
   await successBannerCloseButton.click();
   await expect(successBanner).not.toBeAttached();
 
-  page.close();
+  await page.close();
 
   const context = await browser.newContext();
   const newPage = await context.newPage();
@@ -84,7 +84,7 @@ test("dismissed permanent success banner is not shown in new page", async ({
   const newSuccessBannerCloseButton = newPage
     .getByRole("status")
     .filter({ hasText: "This is a permanent success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(newSuccessBanner).toBeAttached();
 

--- a/tests/alertbox-session.spec.js
+++ b/tests/alertbox-session.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { chromium, test, expect } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 test("has manager and five banners", async ({ page }) => {
   await page.goto("/components/alertbox/session.html");
@@ -22,7 +22,7 @@ test("session success banner has dismissible close button", async ({
   const successBannerCloseButton = page
     .getByRole("status")
     .filter({ hasText: "This is a session success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(successBanner).toBeAttached();
   await expect(successBannerCloseButton).toBeAttached();
@@ -39,7 +39,7 @@ test("dismissed session success banner is not shown again after reload", async (
   const successBannerCloseButton = page
     .getByRole("status")
     .filter({ hasText: "This is a session success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(successBanner).toBeAttached();
   await expect(successBannerCloseButton).toBeAttached();
@@ -53,6 +53,7 @@ test("dismissed session success banner is not shown again after reload", async (
 });
 
 test("dismissed session success banner is shown in new context", async ({
+  browser,
   page,
 }) => {
   await page.goto("/components/alertbox/session.html");
@@ -63,7 +64,7 @@ test("dismissed session success banner is shown in new context", async ({
   const successBannerCloseButton = page
     .getByRole("status")
     .filter({ hasText: "This is a session success alertbox" })
-    .getByRole("button");
+    .getByRole("button", { name: "Close" });
 
   await expect(successBanner).toBeAttached();
   await expect(successBannerCloseButton).toBeAttached();
@@ -71,9 +72,8 @@ test("dismissed session success banner is shown in new context", async ({
   await successBannerCloseButton.click();
   await expect(successBanner).not.toBeAttached();
 
-  page.close();
+  await page.close();
 
-  const browser = await chromium.launch();
   const context = await browser.newContext();
   const newPage = await context.newPage();
   await newPage.goto("/components/alertbox/session.html");
@@ -84,6 +84,5 @@ test("dismissed session success banner is shown in new context", async ({
 
   await expect(newSuccessBanner).toBeAttached();
 
-  await page.close();
   await context.close();
 });

--- a/tests/alertbox.spec.js
+++ b/tests/alertbox.spec.js
@@ -16,11 +16,11 @@ test("default banner has dismissible close button", async ({ page }) => {
 
   const defaultBanner = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" });
+    .filter({ hasText: "This is an info alertbox" });
   const defaultBannerCloseButton = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" })
-    .getByRole("button");
+    .filter({ hasText: "This is an info alertbox" })
+    .getByRole("button", { name: "Close" });
 
   await expect(defaultBanner).toBeAttached();
   await expect(defaultBannerCloseButton).toBeAttached();
@@ -46,11 +46,11 @@ test("clicking close button removes banner", async ({ page }) => {
 
   const defaultBanner = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" });
+    .filter({ hasText: "This is an info alertbox" });
   const defaultBannerCloseButton = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" })
-    .getByRole("button");
+    .filter({ hasText: "This is an info alertbox" })
+    .getByRole("button", { name: "Close" });
 
   await expect(defaultBanner).toBeAttached();
   await expect(defaultBannerCloseButton).toBeAttached();
@@ -64,11 +64,11 @@ test("banner is shown again after page reload", async ({ page }) => {
 
   const defaultBanner = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" });
+    .filter({ hasText: "This is an info alertbox" });
   const defaultBannerCloseButton = page
     .getByRole("status")
-    .filter({ hasText: "This is a basic alertbox" })
-    .getByRole("button");
+    .filter({ hasText: "This is an info alertbox" })
+    .getByRole("button", { name: "Close" });
 
   await expect(defaultBanner).toBeAttached();
   await expect(defaultBannerCloseButton).toBeAttached();


### PR DESCRIPTION
## Summary
- Split Playwright CI into Chromium, Firefox, and WebKit jobs with manual browser selection
- Reduce CI retry count and keep browser-specific reports as separate artifacts
- Tighten alertbox dismissal logic for session and permanent banners
- Update Playwright tests to target the Close button explicitly and align session handling

## Testing
- Playwright UI tests updated to cover banner dismissal and cross-context behavior
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Playwright CI with optional per-browser runs (chromium, firefox, webkit) and browser-specific reports.

* **Bug Fixes**
  * Improved alert box dismissal behavior to correctly handle session vs permanent dismissals and tightened dismissal persistence logic.
  
* **Tests**
  * Updated Playwright alert box specs to use clearer, accessible close-button selectors and improved page/context cleanup to avoid flaky timing.

* **Chores**
  * Refined Playwright CI workflow conditions, reduced CI retries, lowered per-browser job timeouts, and limited workflow permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->